### PR TITLE
[Feat] 병아리 이름 유저디폴트에서 저장 및 가져오기, 당일 목표시간 설정 및 변경, 달력에서 클릭한 날짜의 목표시간 가…

### DIFF
--- a/PeepPeep/DeviceActivityReportExtension/DeviceActivityExtension.swift
+++ b/PeepPeep/DeviceActivityReportExtension/DeviceActivityExtension.swift
@@ -24,3 +24,10 @@ struct DeviceActivityExtension: DeviceActivityReportExtension {
         }
     }
 }
+
+extension UserDefaults {
+    static var shared: UserDefaults {
+        let appGroupId = "group.7C76V3X7AB.com.restco.PeepPeep"
+        return UserDefaults(suiteName: appGroupId)!
+    }
+}

--- a/PeepPeep/DeviceActivityReportExtension/View/DailyFeedBack/DiaryActivityView.swift
+++ b/PeepPeep/DeviceActivityReportExtension/View/DailyFeedBack/DiaryActivityView.swift
@@ -9,7 +9,8 @@ import Foundation
 import SwiftUI
 
 struct DiaryActivityView: View {
-    let goalTime: Int = 480
+    @State var clickedDate: String = ""
+    @State var goalTime: Int = 480
     let mainActivity : Double
     var color: [Color] = [Color("LightGreen"), .green, .yellow, .orange, .red]
     let formatter: DateComponentsFormatter = {
@@ -34,6 +35,18 @@ struct DiaryActivityView: View {
             Text("\(Int(CGFloat(Int(mainActivity/60.0)) / CGFloat(goalTime) * 100))%")
                 .font(.custom("DOSSaemmul", size: 16))
                 .padding(.top, 7)
+        }
+        .onAppear{
+            let DateFormatter = DateFormatter()
+            DateFormatter.dateFormat = "yyyy.MM.dd"
+            let today = DateFormatter.string(from: Date())
+            clickedDate = UserDefaults.shared.string(forKey: "clickedDate") ?? today
+            //목표설정시간이 없는 날은 목표시간을 240분으로 임의로 설정한다
+            if UserDefaults.shared.object(forKey: clickedDate) == nil {
+                goalTime = 240
+            } else {
+                goalTime = UserDefaults.shared.integer(forKey: clickedDate)
+            }
         }
     }
 }

--- a/PeepPeep/DeviceActivityReportExtension/View/MainScreen/MainActivityView.swift
+++ b/PeepPeep/DeviceActivityReportExtension/View/MainScreen/MainActivityView.swift
@@ -9,7 +9,9 @@ import SwiftUI
 
 struct MainActivityView: View {
     @State private var currentTime = Date()
-    let goalTime: Int = 480
+    @State var goalTime: Int = 480
+    @State var chickName: String = "병아리"
+    let gaugeWidth : CGFloat = 106
     let mainActivity : Double
     var color: [Color] = [Color("LightGreen"), .green, .yellow, .orange, .red]
     let formatter: DateComponentsFormatter = {
@@ -34,7 +36,7 @@ struct MainActivityView: View {
             ZStack{
                 RoundedRectangle(cornerRadius: 5)
                     .fill(.white)
-                    .frame(width: 106, height: 24)
+                    .frame(width: gaugeWidth, height: 24)
                     .overlay{
                         RoundedRectangle(cornerRadius: 5)
                             .stroke(Color.black)
@@ -42,7 +44,7 @@ struct MainActivityView: View {
                     .overlay(alignment: .leading){
                         RoundedRectangle(cornerRadius: 5)
                             .fill(statusColor(stress: Int(CGFloat(Int(mainActivity/60.0)) / CGFloat(goalTime) * 100)))
-                            .frame(width: (CGFloat(Int(mainActivity/60.0)) / CGFloat(goalTime) * 106))
+                            .frame(width: ((CGFloat(Int(mainActivity/60.0)) / CGFloat(goalTime) * gaugeWidth) > CGFloat(gaugeWidth) ? CGFloat(gaugeWidth) : CGFloat(Int(mainActivity/60.0)) / CGFloat(goalTime) * gaugeWidth))
                     }
 
                 Text("\(Int(CGFloat(Int(mainActivity/60.0)) / CGFloat(goalTime) * 100))%")
@@ -59,17 +61,30 @@ struct MainActivityView: View {
                 chickImage(stress: Int(CGFloat(Int(mainActivity/60.0)) / CGFloat(goalTime) * 100))
                     .resizable()
                     .frame(width: 250, height: 250, alignment: .center)
-                Text("Lv. 1")
-                    .font(.custom("DOSSaemmul", size: 13))
-                Text("병만이")
-                    .font(.custom("DOSSaemmul", size: 20))
-                    .padding(.top, 3)
             }
+            Text("Lv. 1")
+                .font(.custom("DOSSaemmul", size: 13))
+            Text(chickName)
+                .font(.custom("DOSSaemmul", size: 20))
+                .padding(.top, 3)
             
+        }
+        .onAppear{
+            let DateFormatter = DateFormatter()
+            DateFormatter.dateFormat = "yyyy.MM.dd"
+            let today = DateFormatter.string(from: Date())
+            //오늘 목표 설정시간이 있다면 가져오고 없다면 240분이 목표시간 기본값
+            if UserDefaults.shared.object(forKey: today) == nil {
+                goalTime = 240
+            } else{
+                goalTime = UserDefaults.shared.integer(forKey: today)
+            }
+            chickName = UserDefaults.shared.string(forKey: "chickName") ?? "병아리"
         }
         //60초 마다 현재 시간을 업데이트
         .onReceive(Timer.publish(every: 1, on: .main, in: .common).autoconnect()) { _ in
             self.currentTime = Date()
+            
         }
     }
     private func isWithinRange() -> Bool {
@@ -107,7 +122,7 @@ func statusColor(stress: Int) -> Color {
         return color[2]
     case 60 ..< 80 :
         return color[3]
-    case 80 ..< 100 :
+    case 80 ..< 1000 :
         return color[4]
     default:
         return color[1]

--- a/PeepPeep/PeepPeep/PeepPeepApp.swift
+++ b/PeepPeep/PeepPeep/PeepPeepApp.swift
@@ -15,3 +15,10 @@ struct PeepPeepApp: App {
         }
     }
 }
+//앱그룹을 이용해 유저디폴트를 익스텐션으로 전달할 때 사용하는 코드
+extension UserDefaults {
+    static var shared: UserDefaults {
+        let appGroupId = "group.7C76V3X7AB.com.restco.PeepPeep"
+        return UserDefaults(suiteName: appGroupId)!
+    }
+}

--- a/PeepPeep/PeepPeep/View/DailyFeedBack/DailyFeedBackView.swift
+++ b/PeepPeep/PeepPeep/View/DailyFeedBack/DailyFeedBackView.swift
@@ -154,19 +154,6 @@ struct DiaryView: View {
                     .padding(.top)
                 DeviceActivityReport(context, filter: filter)
                     .frame(width: 150, height: 180)
-//                    .background(Color(hex: "f6efe3"))
-
-//                VStack {
-//                    Text("사용시간")
-//                    DeviceActivityReport(context, filter: filter)
-//                        .frame(width: 100, height: 30)
-//                }
-//                .padding(.bottom)
-//
-//                Text("스트레스 지수")
-//                    .padding(.bottom, 3)
-//                Text("\(stressLevel)%")
-//                    .font(.title2)
             }
             Image("Chick")
                 .resizable()
@@ -174,6 +161,12 @@ struct DiaryView: View {
                 .frame(height: 200)
                 .offset(x: -120, y: 75)
                 .scaleEffect(x: -1, y: 1, anchor: .center)
+        }
+        .onAppear{
+            let DateFormatter = DateFormatter()
+            DateFormatter.dateFormat = "yyyy.MM.dd"
+            let clickedDate = DateFormatter.string(from: nowDay)
+            UserDefaults.shared.set(clickedDate, forKey: "clickedDate")
         }
     }
 }

--- a/PeepPeep/PeepPeep/View/InitialSetupScreen/ChickNamingView.swift
+++ b/PeepPeep/PeepPeep/View/InitialSetupScreen/ChickNamingView.swift
@@ -33,6 +33,9 @@ struct ChickNamingView: View {
             .navigationBarItems(trailing: SkipButton(viewModel: viewModel, name: name))
             .font(.dosSsaemmul(size: 20))
             .foregroundColor(Color.black)
+            .onAppear{
+                print(name)
+            }
         }
     }
 }
@@ -63,16 +66,22 @@ struct ChickImageView: View {
 struct DecisionButton: View {
     let viewModel: ChickNamingViewModel
     let name: String
-
+    
     var body: some View {
-        Button(action: {
-            viewModel.updateChickName(name: name)
-        }) {
-            NavigationLink(destination: ScreenTimeRequestView()) {
-                Text("결정")
-            }
+        NavigationLink {
+            ScreenTimeRequestView()
+        } label: {
+            Text("결정")
         }
         .buttonStyle(CommonButtonStyle(paddingSize: 30))
+        .simultaneousGesture(TapGesture().onEnded({ _ in
+            // 아무것도 입력하지 않고 결정을 누르면 기본값 "병아리"로 이름이 지어짐
+            if name == "" {
+                viewModel.updateChickName(name: "병아리")
+            } else{
+                viewModel.updateChickName(name: name)
+            }
+        }))
     }
 }
 
@@ -82,12 +91,14 @@ struct SkipButton: View {
     let name: String
 
     var body: some View {
-        Button(action: {
-            viewModel.updateChickName(name: "병아리")
-        }) {
-            NavigationLink(destination: ScreenTimeRequestView()) {
-                Text("Skip")
-            }
+        NavigationLink {
+            ScreenTimeRequestView()
+        } label: {
+            Text("Skip")
         }
+        .simultaneousGesture(TapGesture().onEnded({ _ in
+            // 스키밯면 기본값 "병아리"로 이름이 지어짐
+            viewModel.updateChickName(name: "병아리")
+        }))
     }
 }

--- a/PeepPeep/PeepPeep/View/InitialSetupScreen/TimeSettingView.swift
+++ b/PeepPeep/PeepPeep/View/InitialSetupScreen/TimeSettingView.swift
@@ -9,10 +9,11 @@ import SwiftUI
 import DeviceActivity
 
 struct TimeSettingView: View {
-    let hours = [0, 1, 2, 3, 4, 5, 6, 7, 8]
+    let hours = Array(0...23)
     let minutes = [0, 10, 20, 30, 40, 50]
     @State var selectedHours = 4
     @State var selectedMinutes = 0
+    @State var testGoalTime = 0
     
     var body: some View {
         VStack {
@@ -52,7 +53,12 @@ struct TimeSettingView: View {
             }
             .padding(.vertical, 20)
             Button {
-                print("결정")
+                let goalTime = hours[hours.firstIndex(of: selectedHours) ?? 0]*60 + minutes[minutes.firstIndex(of: selectedMinutes) ?? 0]
+                let DateFormatter = DateFormatter()
+                DateFormatter.dateFormat = "yyyy.MM.dd"
+                let settedDay = DateFormatter.string(from: Date())
+                UserDefaults.shared.set(goalTime, forKey: settedDay)
+                testGoalTime = UserDefaults.shared.integer(forKey: settedDay)
             } label: {
                 Text("결정")
                     .frame(width: 106, height: 44)
@@ -64,6 +70,25 @@ struct TimeSettingView: View {
                     }
             }
             .padding(.vertical, 20)
+            .onAppear{
+                for (key, value) in UserDefaults.shared.dictionaryRepresentation() {
+                   print("\(key), \(value)")
+                 }
+                let dateFormatter = DateFormatter()
+                dateFormatter.dateFormat = "yyyy.MM.dd"
+                let today = dateFormatter.string(from: Date())
+                if UserDefaults.shared.object(forKey: today) == nil {
+                    // 기존 설정된 목표시간이 없다면 4시간 0분이 기본값
+                    selectedHours = 4
+                    selectedMinutes = 0
+                } else {
+                    // 기존 설정된 목표시간이 있다면 피커가 그 시간에 맞게 세팅이 되어 나옴
+                    testGoalTime = UserDefaults.shared.integer(forKey: today)
+                    selectedHours = hours.firstIndex(of: testGoalTime / 60) ?? 4
+                    selectedMinutes = minutes.firstIndex(of: testGoalTime % 60) ?? 0
+                }
+            }
+//            Text("현재목표시간 : \(testGoalTime)")
         }
     }
 }

--- a/PeepPeep/PeepPeep/View/MainScreen/MainView.swift
+++ b/PeepPeep/PeepPeep/View/MainScreen/MainView.swift
@@ -16,6 +16,18 @@ struct MainView: View {
     @State private var context: DeviceActivityReport.Context = .mainActivity
     @State private var showModal = false
     @State private var showModal2 = false
+    @State private var filter: DeviceActivityFilter = {
+            let now = Date()
+            let startOfDay = Calendar.current.startOfDay(for: now)
+            let endOfDay = Calendar.current.date(byAdding: .day, value: 1, to: startOfDay) ?? now
+            let dateInterval = DateInterval(start: startOfDay, end: endOfDay)
+        
+            return DeviceActivityFilter(
+                segment: .daily(during: dateInterval),
+                users: .all,
+                devices: .init([.iPhone, .iPad])
+            )
+        }()
     
     var currentUsageTime: CGFloat = 217  // minutes, 사용시간
     var targetUsageTime: CGFloat = 240   // minutes, 목표시간
@@ -25,6 +37,7 @@ struct MainView: View {
     var body: some View {
         NavigationStack{
             VStack{
+
                 // 도움말 ModalView
                 HStack{
                     Button(action: {
@@ -51,7 +64,7 @@ struct MainView: View {
                 Spacer()
                                 
 //                ProgressBarView()
-                DeviceActivityReport(context)
+                DeviceActivityReport(context, filter: filter)
                     .frame(width: 300, height: 500, alignment: .center)
                 
                 
@@ -77,8 +90,8 @@ struct MainView: View {
                     Spacer()
                     
                     // 시간설정 버튼
-                    Button {
-                        self.showModal2 = true
+                    NavigationLink {
+                        SettingView()
                     } label: {
                         VStack{
                             Image("Setting")
@@ -89,11 +102,7 @@ struct MainView: View {
                                 .font(.custom("DOSSaemmul", size: 16))
                         }
                     }
-                    .sheet(isPresented: self.$showModal2){
-                        TimeSettingView()
-                            .presentationDetents([.large])
-                            .presentationDragIndicator(.visible)
-                    }
+
                     
                     Spacer()
                     

--- a/PeepPeep/PeepPeep/View/Setting/SettingView.swift
+++ b/PeepPeep/PeepPeep/View/Setting/SettingView.swift
@@ -11,7 +11,7 @@ import Foundation
 struct SettingView: View {
     
     let grayColor: Color = Color("GrayColor")
-    @State var name: String = ""
+    @State var chickName: String = ""
     @State var showModal = false
     
     var body: some View {
@@ -27,9 +27,11 @@ struct SettingView: View {
                     .font(.custom("DOSSaemmul", size: 15))
                     .foregroundColor(grayColor)
                 
-                TextField("병아리", text: $name)
+                TextField(chickName, text: $chickName)
                     .font(.custom("DOSSaemmul", size: 15))
-                    
+                    .onSubmit {
+                        UserDefaults.shared.set(chickName, forKey: "chickName")
+                    }
             }
             .frame(width: 320, height: 60)
             .overlay(){
@@ -58,9 +60,10 @@ struct SettingView: View {
             
             Spacer()
 
-            
         } // VStack
-        
+        .onAppear{
+            chickName = UserDefaults.shared.string(forKey: "chickName") ?? "병아리"
+        }
     }
         
 }

--- a/PeepPeep/PeepPeep/ViewModel/ChickNamingVIewModel.swift
+++ b/PeepPeep/PeepPeep/ViewModel/ChickNamingVIewModel.swift
@@ -10,6 +10,7 @@ class ChickNamingViewModel: ObservableObject {
     @Published var chick: Chick?
 
     func updateChickName(name: String) {
-        chick = Chick(name: name)
+        //유저디폴트 Key "chickName" 에 병아리 이름을 저장
+        UserDefaults.shared.set(name, forKey: "chickName")
     }
 }


### PR DESCRIPTION
## 개요 및 관련 이슈
- 병아리 이름 저장 및 표시
- 당일 목표 시간 저장, 변경 및 달성률에 반영
- 달력에서 클릭한 날짜별로 그날의 목표시간 가져와서 달성률에 반영


## 작업 사항
병아리 이름 : 병아리 이름을 유저디폴트에 저장하여 이를 레포트에서 가져다 사용하고, 설정창에서 변경할 수 있도록 함
목표시간설정 : 목표시간을 설정하면 해당일을 키로하여 유저디폴트에 목표시간이 저장됨, 현재는 변경횟수 제한은 없음 차후에 제한을 두도록함
달력의 날짜별 목표시간 : 날짜를 클릭하면 해당 날짜가 clickedDate 라는 키의 유저디폴트에 저장됨. DiaryReport 에서는 clickedDate 값을 가져와서 그 날짜의 목표시간을 유저디폴트에서 다시 받아오고 이 것이 달력 화면에 표출됨

## 사진 또는 영상(Optional)

<img src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team12-PeepPeep/assets/83645833/5fd74a5c-4dd4-4255-b7ee-12f26d76647d" width="150" height="300"/>

<img src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team12-PeepPeep/assets/83645833/62a781dc-47d4-4afa-97cb-2b40c7df6d7d" width="150" height="300"/>

<img src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team12-PeepPeep/assets/83645833/e5c6256a-e842-48f0-8908-60fd482fb465" width="150" height="300"/>

<img src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team12-PeepPeep/assets/83645833/8cf746c3-90c9-42fd-9044-2c158a22a726" width="150" height="300"/>

병아리 이름 변경, 목표시간 변경창, 목표시간이 변경되어 달성률이 변한 모습, 날짜별로 목표시간을 다르게 표시