### PR TITLE
[Feat] 메인뷰, 달력뷰에서 계산하는 당일 목표시간이 없으면 가장 최근 설정한 목표시간을 반영, 달력뷰에서 앱을 다운 받…

### DIFF
--- a/PeepPeep/DeviceActivityReportExtension/View/DailyFeedBack/DiaryActivityView.swift
+++ b/PeepPeep/DeviceActivityReportExtension/View/DailyFeedBack/DiaryActivityView.swift
@@ -9,6 +9,8 @@ import Foundation
 import SwiftUI
 
 struct DiaryActivityView: View {
+    @State var dateBeforeDownload: Bool = false
+    @State var downloadedDate: String = ""
     @State var clickedDate: String = ""
     @State var goalTime: Int = 480
     let mainActivity : Double
@@ -24,28 +26,49 @@ struct DiaryActivityView: View {
     
     var body: some View {
         VStack {
-            Text("사용 시간")
-                .font(.custom("DOSSaemmul", size: 11))
-            Text(formatter.string(from: mainActivity) ?? "0시간0분")
-                .font(.custom("DOSSaemmul", size: 20))
-                .padding(.top, 7)
-            Text("스트레스 지수")
-                .font(.custom("DOSSaemmul", size: 12))
-                .padding(.top, 30)
-            Text("\(Int(CGFloat(Int(mainActivity/60.0)) / CGFloat(goalTime) * 100))%")
-                .font(.custom("DOSSaemmul", size: 16))
-                .padding(.top, 7)
+            if dateBeforeDownload {
+                Text("사용 시간")
+                    .font(.custom("DOSSaemmul", size: 11))
+                Text(formatter.string(from: mainActivity) ?? "0시간0분")
+                    .font(.custom("DOSSaemmul", size: 20))
+                    .padding(.top, 7)
+                Text("병아리를\n만나기\n전입니다")
+                    .font(.custom("DOSSaemmul", size: 12))
+                    .padding(.top, 30)
+            } else {
+                Text("사용 시간")
+                    .font(.custom("DOSSaemmul", size: 11))
+                Text(formatter.string(from: mainActivity) ?? "0시간0분")
+                    .font(.custom("DOSSaemmul", size: 20))
+                    .padding(.top, 7)
+                Text("스트레스 지수")
+                    .font(.custom("DOSSaemmul", size: 12))
+                    .padding(.top, 30)
+                Text("\(Int(CGFloat(Int(mainActivity/60.0)) / CGFloat(goalTime) * 100))%")
+                    .font(.custom("DOSSaemmul", size: 16))
+                    .padding(.top, 7)
+//                Text("테스트용 목표시간")
+//                    .font(.custom("DOSSaemmul", size: 12))
+//                Text("\(goalTime)")
+//                    .font(.custom("DOSSaemmul", size: 12))
+            }
         }
         .onAppear{
-            let DateFormatter = DateFormatter()
-            DateFormatter.dateFormat = "yyyy.MM.dd"
-            let today = DateFormatter.string(from: Date())
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyy.MM.dd"
+            let today = dateFormatter.string(from: Date())
             clickedDate = UserDefaults.shared.string(forKey: "clickedDate") ?? today
-            //목표설정시간이 없는 날은 목표시간을 240분으로 임의로 설정한다
-            if UserDefaults.shared.object(forKey: clickedDate) == nil {
-                goalTime = 240
-            } else {
-                goalTime = UserDefaults.shared.integer(forKey: clickedDate)
+            downloadedDate = UserDefaults.shared.string(forKey: "downloadedDate") ?? "2023.07.17"
+            //클릭한 날짜를 다운로드한 날짜와 비교해서, 전자가 후자보다 빠르면 dateBeforeDownload 를 true로 바꾸어 코드를 분기
+            if dateFormatter.date(from: clickedDate)?.compare((dateFormatter.date(from: downloadedDate) ?? dateFormatter.date(from: "2023.07.17"))!) == .orderedAscending {
+                dateBeforeDownload = true
+            } else{
+                //달력에서 클릭한 날짜의 목표시간이 없다면, 이전 날짜를 하나씩 검사하며 가장 최근에 설정된 목표시간을 가져와 반영
+                var dayCount = 0
+                while (UserDefaults.shared.object(forKey: dateFormatter.string(from: Calendar.current.date(byAdding: .day, value: dayCount, to: dateFormatter.date(from: clickedDate)!)!)) == nil){
+                    dayCount -= 1
+                }
+                goalTime = UserDefaults.shared.integer(forKey: dateFormatter.string(from: Calendar.current.date(byAdding: .day, value: dayCount, to: dateFormatter.date(from: clickedDate)!)!))
             }
         }
     }

--- a/PeepPeep/DeviceActivityReportExtension/View/MainScreen/MainActivityView.swift
+++ b/PeepPeep/DeviceActivityReportExtension/View/MainScreen/MainActivityView.swift
@@ -70,15 +70,16 @@ struct MainActivityView: View {
             
         }
         .onAppear{
-            let DateFormatter = DateFormatter()
-            DateFormatter.dateFormat = "yyyy.MM.dd"
-            let today = DateFormatter.string(from: Date())
-            //오늘 목표 설정시간이 있다면 가져오고 없다면 240분이 목표시간 기본값
-            if UserDefaults.shared.object(forKey: today) == nil {
-                goalTime = 240
-            } else{
-                goalTime = UserDefaults.shared.integer(forKey: today)
+            let today = Date()
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyy.MM.dd"
+            //메인화면에서 병아리의 상태를 표출할 때, 이전 날짜를 하나씩 검사하며 목표 시간 설정이 된 가장 최근 날짜의 목표시간을 가져와 반영
+            //목표시간이 설정된 적이 없으면 무한루프를 돌기에, 메인화면이 나타날 때 onAppear 로 7월17일의 목표시간을 600분으로 임의로 정함
+            var dayCount = 0
+            while (UserDefaults.shared.object(forKey: dateFormatter.string(from: Calendar.current.date(byAdding: .day, value: dayCount, to: today)!)) == nil){
+                dayCount -= 1
             }
+            goalTime = UserDefaults.shared.integer(forKey: dateFormatter.string(from: Calendar.current.date(byAdding: .day, value: dayCount, to: today)!))
             chickName = UserDefaults.shared.string(forKey: "chickName") ?? "병아리"
         }
         //60초 마다 현재 시간을 업데이트

--- a/PeepPeep/PeepPeep/View/DailyFeedBack/DailyFeedBackView.swift
+++ b/PeepPeep/PeepPeep/View/DailyFeedBack/DailyFeedBackView.swift
@@ -153,7 +153,8 @@ struct DiaryView: View {
                     .font(.custom("DOSSaemmul", size: 13))
                     .padding(.top)
                 DeviceActivityReport(context, filter: filter)
-                    .frame(width: 150, height: 180)
+                    .frame(width: 120, height: 144)
+                    
             }
             Image("Chick")
                 .resizable()
@@ -163,9 +164,9 @@ struct DiaryView: View {
                 .scaleEffect(x: -1, y: 1, anchor: .center)
         }
         .onAppear{
-            let DateFormatter = DateFormatter()
-            DateFormatter.dateFormat = "yyyy.MM.dd"
-            let clickedDate = DateFormatter.string(from: nowDay)
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyy.MM.dd"
+            let clickedDate = dateFormatter.string(from: nowDay)
             UserDefaults.shared.set(clickedDate, forKey: "clickedDate")
         }
     }

--- a/PeepPeep/PeepPeep/View/MainScreen/MainView.swift
+++ b/PeepPeep/PeepPeep/View/MainScreen/MainView.swift
@@ -12,7 +12,6 @@ extension DeviceActivityReport.Context{
 }
 
 struct MainView: View {
-//    @State private var mainContext: DeviceActivityReport.Context = .init(rawValue: "Main Activity")
     @State private var context: DeviceActivityReport.Context = .mainActivity
     @State private var showModal = false
     @State private var showModal2 = false
@@ -123,6 +122,11 @@ struct MainView: View {
                 } // 하단 메뉴 HStack
                 Spacer()
             }   // VStack
+            .onAppear{
+                //앱이 처음 다운로드 된 날, 그 날의 목표시간을 유저디폴트에 저장합니다(향후 온보딩 및 초기 설정 페이지로 옮겨야 합니다)
+                UserDefaults.shared.set("2023.07.17", forKey: "downloadedDate")
+                UserDefaults.shared.set(600, forKey: "2023.07.17")
+            }
         }   // NavigationStack
     }
 }


### PR DESCRIPTION
## 개요 및 관련 이슈
- 메인뷰, 달력뷰 계산해야 하는 당일 목표 시간이 없으면 가장 최근에 설정한 목표시간을 반영
- 달력뷰에서 앱 다운로드 이전의 날짜를 클릭하면 "병아리를 만나기 전입니다" 표시
- 이를 위해 메인뷰에 onAppear 로 다운로드 날짜와 그 날의 목표 시간 세팅을 더미 데이터로 저장


## 작업 사항
- 메인레포트뷰, 달력레포트뷰에서 요청날짜기준으로 이전날짜를 하루씩 검색하면서 목표시간이 저장된 값을 찾으면 이를 뷰에 반영한다
- 앱 다운로드 날짜와 그날의 목표 시간 세팅을 더미데이터로 저장해놓고, 이 날짜 이전의 날짜를 달력에서 클릭하면 "병아리를 만나기 전입니다" 표시

## 사진 또는 영상(Optional)

<img src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team12-PeepPeep/assets/83645833/86ccf4fc-dcfa-40ff-8f5a-6f9c18810aa9" width="200" height="400"/>

<img src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team12-PeepPeep/assets/83645833/03ca2391-9de0-4c2d-b527-74a04613b46f" width="200" height="400"/>

<img src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team12-PeepPeep/assets/83645833/8f2685df-73b6-48fe-b136-0a7e164df07f" width="200" height="400"/>

2번 사진은 목표시간을 설정해주지 않아도, 전날(1번사진) 의 목표시간(10시간)을 따라가는 모습 
7월17일이 앱 다운로드 일이니까 7월 16일을 클릭하면 "병아리를 만나기 전입니다" 메시지