### PR TITLE
[Feat] 목표 시간 설정을 하루에 한번만 할 수 있게하는 기능 추가

### DIFF
--- a/PeepPeep/PeepPeep/View/InitialSetupScreen/TimeSettingView.swift
+++ b/PeepPeep/PeepPeep/View/InitialSetupScreen/TimeSettingView.swift
@@ -11,8 +11,10 @@ import DeviceActivity
 struct TimeSettingView: View {
     let hours = Array(0...23)
     let minutes = [0, 10, 20, 30, 40, 50]
+    @State var buttonDisabledCheck = false
     @State var selectedHours = 4
     @State var selectedMinutes = 0
+    @State var goalTime: Int = 240
     @State var testGoalTime = 0
     
     var body: some View {
@@ -23,6 +25,7 @@ struct TimeSettingView: View {
             Text("하루에 한번만 설정을 바꿀 수 있습니다")
                 .font(.custom("DOSSaemmul", size: 13))
                 .padding(.vertical, 20)
+                .foregroundColor(buttonDisabledCheck ? .red : .black)
             HStack {
                 Picker("hourPicker", selection: $selectedHours) {
                     ForEach(hours, id: \.self) { hour in
@@ -59,16 +62,20 @@ struct TimeSettingView: View {
                 let settedDay = dateFormatter.string(from: Date())
                 UserDefaults.shared.set(goalTime, forKey: settedDay)
                 testGoalTime = UserDefaults.shared.integer(forKey: settedDay)
+                //버튼이 터치되면서 버튼색,글씨색이 바뀜
+                buttonDisabledCheck = true
             } label: {
                 Text("결정")
                     .frame(width: 106, height: 44)
                     .font(.custom("DOSSaemmul", size: 20))
-                    .foregroundColor(.black)
+                    //오늘 설정을 한번 설정을 한 상태라면 버튼 색이 라이트그레이로 바뀜
+                    .foregroundColor(buttonDisabledCheck ? Color("LightGray") : .black)
                     .overlay {
                         RoundedRectangle(cornerRadius: 15)
-                            .stroke(.black, lineWidth: 1)
+                            .stroke(buttonDisabledCheck ? Color("LightGray") : .black, lineWidth: 1)
                     }
             }
+            .disabled(buttonDisabledCheck)
             .padding(.vertical, 20)
             .onAppear{
                 for (key, value) in UserDefaults.shared.dictionaryRepresentation() {
@@ -77,15 +84,22 @@ struct TimeSettingView: View {
                 let dateFormatter = DateFormatter()
                 dateFormatter.dateFormat = "yyyy.MM.dd"
                 let today = dateFormatter.string(from: Date())
+                // 오늘 날짜의 목표시간이 없으면 가장 최근에 설정한 목표시간을 찾아 피커에 띄워준다
                 if UserDefaults.shared.object(forKey: today) == nil {
-                    // 기존 설정된 목표시간이 없다면 4시간 0분이 기본값
-                    selectedHours = 4
-                    selectedMinutes = 0
+                    var dayCount = 0
+                    while (UserDefaults.shared.object(forKey: dateFormatter.string(from: Calendar.current.date(byAdding: .day, value: dayCount, to: Date())!)) == nil){
+                        dayCount -= 1
+                    }
+                    goalTime = UserDefaults.shared.integer(forKey: dateFormatter.string(from: Calendar.current.date(byAdding: .day, value: dayCount, to: Date())!))
+                    selectedHours = hours.firstIndex(of: goalTime / 60) ?? 4
+                    selectedMinutes = minutes.firstIndex(of: goalTime % 60) ?? 0
+
                 } else {
-                    // 기존 설정된 목표시간이 있다면 피커가 그 시간에 맞게 세팅이 되어 나옴
-                    testGoalTime = UserDefaults.shared.integer(forKey: today)
-                    selectedHours = hours.firstIndex(of: testGoalTime / 60) ?? 4
-                    selectedMinutes = minutes.firstIndex(of: testGoalTime % 60) ?? 0
+                    // 오늘 설정된 목표시간이 있으면 buttonDisabledCheck 를 true 로 바꾸어 클릭이 안되게 한다, 피커도 오늘 날짜 기준으로 설정
+                    goalTime = UserDefaults.shared.integer(forKey: today)
+                    selectedHours = hours.firstIndex(of: goalTime / 60) ?? 4
+                    selectedMinutes = minutes.firstIndex(of: goalTime % 60) ?? 0
+                    buttonDisabledCheck = true
                 }
             }
 //            Text("현재목표시간 : \(testGoalTime)")


### PR DESCRIPTION
## 개요 및 관련 이슈
- 목표 시간을 하루에 한번만 설정할 수 있도록 하는 기능 추가

## 작업 사항
- 목표시간 피커가 가장 마지막에 목표시간을 설정한 값으로 세팅되도록 함
- 오늘 목표시간 설정 값이 UserDefault에 존재하면 buttonDisabledCheck 를 true로 바꾼다
- buttonDisablesCheck 조건으로 하는 삼항연산자를 이용해, 이 값이 true 면 결정 버튼 색을 밝은 회색으로 바꾸고, "하루에 한번만 설정을..." 문구도 빨간색으로 바꾸도록 함

## 사진 또는 영상(Optional)
<img src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team12-PeepPeep/assets/83645833/79a97133-5090-4af7-af20-f00444897140" width="200" height="400"/>
