### PR TITLE
[Feat/#77] MainView와 MainActivityView 수정

### DIFF
--- a/PeepPeep/DeviceActivityReportExtension/View/MainScreen/MainActivityView.swift
+++ b/PeepPeep/DeviceActivityReportExtension/View/MainScreen/MainActivityView.swift
@@ -30,11 +30,11 @@ struct MainActivityView: View {
             
             Text("0\(Int(mainActivity/3600.0)):\(Int(Int(mainActivity) % 3600)/60 < 10 ? "0\(Int(Int(mainActivity) % 3600)/60)" : "\(Int(Int(mainActivity) % 3600)/60)")")
                 .font(.custom("DOSSaemmul", size: 36))
-                .padding(.top, 10)
+                .padding(.top, 13)
 
             Text("스트레스 지수")
                 .font(.custom("DOSSaemmul", size: 16))
-                .padding(.top, 48)
+                .padding(.top, 58)
             ZStack{
                 RoundedRectangle(cornerRadius: 5)
                     .fill(.white)
@@ -43,33 +43,44 @@ struct MainActivityView: View {
                         RoundedRectangle(cornerRadius: 5)
                             .stroke(Color.black)
                     }
+                // 스트레스 게이지 바
                     .overlay(alignment: .leading){
                         RoundedRectangle(cornerRadius: 3)
                             .fill(statusColor(stress: Int(CGFloat(Int(mainActivity/60.0)) / CGFloat(goalTime) * 100)))
                             .frame(width: ((CGFloat(Int(mainActivity/60.0)) / CGFloat(goalTime) * gaugeWidth) > CGFloat(gaugeWidth) ? CGFloat(gaugeWidth) : CGFloat(Int(mainActivity/60.0)) / CGFloat(goalTime) * gaugeWidth), height: 19.26)
                             .padding(.leading, 2.4)
                     }
-
+                // 스트레스 퍼센트
                 Text("\(Int(CGFloat(Int(mainActivity/60.0)) / CGFloat(goalTime) * 100))%")
                     .font(.custom("DOSSaemmul", size: 17))
                     .foregroundColor(.black)
                 
             }
-            //현재시간이 자정부터 오전 8시 사이면 자는 병아리이미지, 그 외에는 일반이미지
-            if isWithinRange() {
-                Image("Sleep2")
-                    .resizable()
-                    .frame(width: 250, height: 250, alignment: .center)
-            } else {
-                chickImage(stress: Int(CGFloat(Int(mainActivity/60.0)) / CGFloat(goalTime) * 100))
-                    .resizable()
-                    .frame(width: 250, height: 250, alignment: .center)
+            
+            ZStack {
+                //현재시간이 자정부터 오전 8시 사이면 자는 병아리이미지, 그 외에는 일반이미지
+                if isWithinRange() {
+                    Image("Sleep2")
+                        .resizable()
+                        .frame(width: 228, height: 228, alignment: .center)
+                } else {
+                    chickImage(stress: Int(CGFloat(Int(mainActivity/60.0)) / CGFloat(goalTime) * 100))
+                        .resizable()
+                        .frame(width: 247, height: 247, alignment: .center)
+                }
+                VStack{
+                    Spacer()
+                    
+                    Text("Lv. 1")
+                        .font(.custom("DOSSaemmul", size: 13))
+                    
+                    Text(chickName)
+                        .font(.custom("DOSSaemmul", size: 20))
+                        .padding(.top, 13)
+                }
             }
-            Text("Lv. 1")
-                .font(.custom("DOSSaemmul", size: 13))
-            Text(chickName)
-                .font(.custom("DOSSaemmul", size: 20))
-                .padding(.top, 3)
+            
+            Spacer()
             
         }
         .onAppear{

--- a/PeepPeep/DeviceActivityReportExtension/View/MainScreen/MainActivityView.swift
+++ b/PeepPeep/DeviceActivityReportExtension/View/MainScreen/MainActivityView.swift
@@ -27,9 +27,11 @@ struct MainActivityView: View {
         VStack {
             Text("현재 사용 시간")
                 .font(.custom("DOSSaemmul", size: 17))
+            
             Text("0\(Int(mainActivity/3600.0)):\(Int(Int(mainActivity) % 3600)/60 < 10 ? "0\(Int(Int(mainActivity) % 3600)/60)" : "\(Int(Int(mainActivity) % 3600)/60)")")
                 .font(.custom("DOSSaemmul", size: 36))
                 .padding(.top, 10)
+
             Text("스트레스 지수")
                 .font(.custom("DOSSaemmul", size: 16))
                 .padding(.top, 48)

--- a/PeepPeep/DeviceActivityReportExtension/View/MainScreen/MainActivityView.swift
+++ b/PeepPeep/DeviceActivityReportExtension/View/MainScreen/MainActivityView.swift
@@ -11,7 +11,7 @@ struct MainActivityView: View {
     @State private var currentTime = Date()
     @State var goalTime: Int = 480
     @State var chickName: String = "병아리"
-    let gaugeWidth : CGFloat = 106
+    let gaugeWidth : CGFloat = 102
     let mainActivity : Double
     var color: [Color] = [Color("LightGreen"), .green, .yellow, .orange, .red]
     let formatter: DateComponentsFormatter = {
@@ -29,22 +29,23 @@ struct MainActivityView: View {
                 .font(.custom("DOSSaemmul", size: 17))
             Text("0\(Int(mainActivity/3600.0)):\(Int(Int(mainActivity) % 3600)/60 < 10 ? "0\(Int(Int(mainActivity) % 3600)/60)" : "\(Int(Int(mainActivity) % 3600)/60)")")
                 .font(.custom("DOSSaemmul", size: 36))
-                .padding(.top, 7)
+                .padding(.top, 10)
             Text("스트레스 지수")
                 .font(.custom("DOSSaemmul", size: 16))
-                .padding(.top, 30)
+                .padding(.top, 48)
             ZStack{
                 RoundedRectangle(cornerRadius: 5)
                     .fill(.white)
-                    .frame(width: gaugeWidth, height: 24)
+                    .frame(width: 106, height: 24.4)
                     .overlay{
                         RoundedRectangle(cornerRadius: 5)
                             .stroke(Color.black)
                     }
                     .overlay(alignment: .leading){
-                        RoundedRectangle(cornerRadius: 5)
+                        RoundedRectangle(cornerRadius: 3)
                             .fill(statusColor(stress: Int(CGFloat(Int(mainActivity/60.0)) / CGFloat(goalTime) * 100)))
-                            .frame(width: ((CGFloat(Int(mainActivity/60.0)) / CGFloat(goalTime) * gaugeWidth) > CGFloat(gaugeWidth) ? CGFloat(gaugeWidth) : CGFloat(Int(mainActivity/60.0)) / CGFloat(goalTime) * gaugeWidth))
+                            .frame(width: ((CGFloat(Int(mainActivity/60.0)) / CGFloat(goalTime) * gaugeWidth) > CGFloat(gaugeWidth) ? CGFloat(gaugeWidth) : CGFloat(Int(mainActivity/60.0)) / CGFloat(goalTime) * gaugeWidth), height: 19.26)
+                            .padding(.leading, 2.4)
                     }
 
                 Text("\(Int(CGFloat(Int(mainActivity/60.0)) / CGFloat(goalTime) * 100))%")

--- a/PeepPeep/PeepPeep/View/MainScreen/MainView.swift
+++ b/PeepPeep/PeepPeep/View/MainScreen/MainView.swift
@@ -16,6 +16,8 @@ struct MainView: View {
     @State private var showModal = false
     @State private var showModal2 = false
     @State private var showTotalActivity = false
+    @State private var showHelperView = false
+    @State private var showLevelModal = false
     @State private var filter: DeviceActivityFilter = {
         let now = Date()
         let startOfDay = Calendar.current.startOfDay(for: now)
@@ -39,41 +41,44 @@ struct MainView: View {
             VStack{
                 
                 // 도움말 ModalView
-                HStack{
-                    Button(action: {
-                        self.showModal.toggle()
-                    }){
-                        Text("!")
-                            .font(.custom("DOSSaemmul", size: 25))
-                            .background(
-                                Circle()
-                                    .frame(width: 36, height: 36)
-                                    .foregroundColor(lightGray)
-                            )
-                            .foregroundColor(.black)
-                        
-                    }
-                    .sheet(isPresented: self.$showModal){
-                        HelperView()
-                            .presentationDetents([.large])
-                            .presentationDragIndicator(.visible)
-                    }
-                    .padding(EdgeInsets(top: 5, leading: 36, bottom: 5, trailing: 5))
-                    Spacer()
-                }// 도움말 ModalView
+//                HStack{
+//                    Button(action: {
+//                        self.showModal.toggle()
+//                    }){
+//                        Text("!")
+//                            .font(.custom("DOSSaemmul", size: 25))
+//                            .background(
+//                                Circle()
+//                                    .frame(width: 36, height: 36)
+//                                    .foregroundColor(lightGray)
+//                            )
+//                            .foregroundColor(.black)
+//
+//                    }
+//                    .sheet(isPresented: self.$showModal){
+//                        HelperView()
+//                            .presentationDetents([.large])
+//                            .presentationDragIndicator(.visible)
+//                    }
+//                    .padding(EdgeInsets(top: 5, leading: 36, bottom: 5, trailing: 5))
+//                    Spacer()
+//                }// 도움말 ModalView
                 Spacer()
+                    .frame(height: 77)
                 
                 ZStack {
                     // ProgressBarView()
                     DeviceActivityReport(context, filter: filter)
                         .frame(width: 300, height: 500, alignment: .center)
+                    // 터치하면 모달 올라오기
                     VStack{
+                        // 현재 사용 시간 터치
                         Button {
                             showTotalActivity.toggle()
                         } label: {
                             Rectangle()
                                 .foregroundColor(.white.opacity(0.1))
-                                .frame(width: 99, height: 30)
+                                .frame(width: 99, height: 40)
                             
                         }
                         .sheet(isPresented: $showTotalActivity) {
@@ -83,9 +88,40 @@ struct MainView: View {
                         }
                         
                         Spacer()
-                            .frame(height: 390)
+                            .frame(height: 81)
                         
+                        // 스트레스 지수 게이지바 터치
+                        Button {
+                            showHelperView.toggle()
+                        } label: {
+                            Rectangle()
+                                .foregroundColor(.white.opacity(0.1))
+                                .frame(width: 110, height: 30)
+                        }
+                        .sheet(isPresented: $showHelperView) {
+                            HelperView()
+                                .presentationDetents([.height(724)])
+                                .presentationDragIndicator(.visible)
+                        }
                         
+                        Spacer()
+                            .frame(height: 234)
+                        
+                        // 레벨 터치
+                        Button {
+                            showLevelModal.toggle()
+                        } label: {
+                            Rectangle()
+                                .foregroundColor(.white.opacity(0.1))
+                                .frame(width: 49, height: 18)
+                        }
+                        .sheet(isPresented: $showLevelModal) {
+                            Text("레벨")
+                                .presentationDetents([.height(453)])
+                                .presentationDragIndicator(.visible)
+                        }
+
+
                     }
 
                     
@@ -103,8 +139,24 @@ struct MainView: View {
                         VStack{
                             Image("Closet")
                                 .resizable()
-                                .frame(width: 49, height: 49, alignment: .center)
+                                .frame(width: 70, height: 70, alignment: .center)
                             Text("옷장")
+                                .foregroundColor(.black)
+                                .font(.custom("DOSSaemmul", size: 16))
+                        }
+                    }
+                    
+                    Spacer()
+                    
+                    // 성장일지 버튼
+                    NavigationLink {
+                        DailyFeedBackView(isClick: false, month: Date(), nowDay: Date(), stressLevel: 0)
+                    } label: {
+                        VStack{
+                            Image("Diary")
+                                .resizable()
+                                .frame(width: 70, height: 70, alignment: .center)
+                            Text("성장일지")
                                 .foregroundColor(.black)
                                 .font(.custom("DOSSaemmul", size: 16))
                         }
@@ -119,29 +171,13 @@ struct MainView: View {
                         VStack{
                             Image("Setting")
                                 .resizable()
-                                .frame(width: 49, height: 49, alignment: .center)
+                                .frame(width: 70, height: 70, alignment: .center)
                             Text("시간설정")
                                 .foregroundColor(.black)
                                 .font(.custom("DOSSaemmul", size: 16))
                         }
                     }
                     
-                    
-                    Spacer()
-                    
-                    // 성장일지 버튼
-                    NavigationLink {
-                        DailyFeedBackView(isClick: false, month: Date(), nowDay: Date(), stressLevel: 0)
-                    } label: {
-                        VStack{
-                            Image("Diary")
-                                .resizable()
-                                .frame(width: 49, height: 49, alignment: .center)
-                            Text("성장일지")
-                                .foregroundColor(.black)
-                                .font(.custom("DOSSaemmul", size: 16))
-                        }
-                    }
                     Spacer()
                 } // 하단 메뉴 HStack
                 Spacer()

--- a/PeepPeep/PeepPeep/View/MainScreen/MainView.swift
+++ b/PeepPeep/PeepPeep/View/MainScreen/MainView.swift
@@ -41,28 +41,28 @@ struct MainView: View {
             VStack{
                 
                 // 도움말 ModalView
-//                HStack{
-//                    Button(action: {
-//                        self.showModal.toggle()
-//                    }){
-//                        Text("!")
-//                            .font(.custom("DOSSaemmul", size: 25))
-//                            .background(
-//                                Circle()
-//                                    .frame(width: 36, height: 36)
-//                                    .foregroundColor(lightGray)
-//                            )
-//                            .foregroundColor(.black)
-//
-//                    }
-//                    .sheet(isPresented: self.$showModal){
-//                        HelperView()
-//                            .presentationDetents([.large])
-//                            .presentationDragIndicator(.visible)
-//                    }
-//                    .padding(EdgeInsets(top: 5, leading: 36, bottom: 5, trailing: 5))
-//                    Spacer()
-//                }// 도움말 ModalView
+                //                HStack{
+                //                    Button(action: {
+                //                        self.showModal.toggle()
+                //                    }){
+                //                        Text("!")
+                //                            .font(.custom("DOSSaemmul", size: 25))
+                //                            .background(
+                //                                Circle()
+                //                                    .frame(width: 36, height: 36)
+                //                                    .foregroundColor(lightGray)
+                //                            )
+                //                            .foregroundColor(.black)
+                //
+                //                    }
+                //                    .sheet(isPresented: self.$showModal){
+                //                        HelperView()
+                //                            .presentationDetents([.large])
+                //                            .presentationDragIndicator(.visible)
+                //                    }
+                //                    .padding(EdgeInsets(top: 5, leading: 36, bottom: 5, trailing: 5))
+                //                    Spacer()
+                //                }// 도움말 ModalView
                 Spacer()
                     .frame(height: 77)
                 
@@ -83,7 +83,7 @@ struct MainView: View {
                         }
                         .sheet(isPresented: $showTotalActivity) {
                             Text("앱 사용 통계")
-                                .presentationDetents([.height(724)])
+                                .presentationDetents([.height(684)])
                                 .presentationDragIndicator(.visible)
                         }
                         
@@ -100,7 +100,7 @@ struct MainView: View {
                         }
                         .sheet(isPresented: $showHelperView) {
                             HelperView()
-                                .presentationDetents([.height(724)])
+                                .presentationDetents([.height(684)])
                                 .presentationDragIndicator(.visible)
                         }
                         
@@ -116,14 +116,41 @@ struct MainView: View {
                                 .frame(width: 49, height: 18)
                         }
                         .sheet(isPresented: $showLevelModal) {
-                            Text("레벨")
-                                .presentationDetents([.height(453)])
-                                .presentationDragIndicator(.visible)
+                            // 레벨 설명
+                            VStack{
+                                Text("병아리의 레벨")
+                                    .font(.custom("DOSSaemmul", size: 20))
+                                    .padding(.bottom, 18)
+                                
+                                Image("chick")
+                                    .resizable()
+                                    .frame(width: 80, height: 80)
+                                    .padding(.bottom, 26)
+                                
+                                Text("레벨은 목표 사용 시간을 잘 지킨 날짜예요.")
+                                    .font(.custom("DOSSaemmul", size: 17))
+                                    .multilineTextAlignment(.center)
+                                    .padding(.bottom, 25)
+                                
+                                Text("하루 목표 사용 시간을 잘 지키면\n레벨이 1 증가해요.")
+                                    .font(.custom("DOSSaemmul", size: 17))
+                                    .multilineTextAlignment(.center)
+                                    .padding(.bottom, 25)
+                                    .lineSpacing(10)
+                                
+                                Text("하루 목표 사용 시간을 잘 지키지 못하면\n레벨이 오르지 않아요.")
+                                    .font(.custom("DOSSaemmul", size: 17))
+                                    .multilineTextAlignment(.center)
+                                    .lineSpacing(10)
+                                
+                            }
+                            .presentationDetents([.height(419)])
+                            .presentationDragIndicator(.visible)
                         }
-
-
-                    }
-
+                        
+                        
+                    }// 터치하면 모달 올라오기
+                    
                     
                 }
                 

--- a/PeepPeep/PeepPeep/View/MainScreen/MainView.swift
+++ b/PeepPeep/PeepPeep/View/MainScreen/MainView.swift
@@ -15,18 +15,19 @@ struct MainView: View {
     @State private var context: DeviceActivityReport.Context = .mainActivity
     @State private var showModal = false
     @State private var showModal2 = false
+    @State private var showTotalActivity = false
     @State private var filter: DeviceActivityFilter = {
-            let now = Date()
-            let startOfDay = Calendar.current.startOfDay(for: now)
-            let endOfDay = Calendar.current.date(byAdding: .day, value: 1, to: startOfDay) ?? now
-            let dateInterval = DateInterval(start: startOfDay, end: endOfDay)
+        let now = Date()
+        let startOfDay = Calendar.current.startOfDay(for: now)
+        let endOfDay = Calendar.current.date(byAdding: .day, value: 1, to: startOfDay) ?? now
+        let dateInterval = DateInterval(start: startOfDay, end: endOfDay)
         
-            return DeviceActivityFilter(
-                segment: .daily(during: dateInterval),
-                users: .all,
-                devices: .init([.iPhone, .iPad])
-            )
-        }()
+        return DeviceActivityFilter(
+            segment: .daily(during: dateInterval),
+            users: .all,
+            devices: .init([.iPhone, .iPad])
+        )
+    }()
     
     var currentUsageTime: CGFloat = 217  // minutes, 사용시간
     var targetUsageTime: CGFloat = 240   // minutes, 목표시간
@@ -36,7 +37,7 @@ struct MainView: View {
     var body: some View {
         NavigationStack{
             VStack{
-
+                
                 // 도움말 ModalView
                 HStack{
                     Button(action: {
@@ -61,11 +62,34 @@ struct MainView: View {
                     Spacer()
                 }// 도움말 ModalView
                 Spacer()
-                                
-//                ProgressBarView()
-                DeviceActivityReport(context, filter: filter)
-                    .frame(width: 300, height: 500, alignment: .center)
                 
+                ZStack {
+                    // ProgressBarView()
+                    DeviceActivityReport(context, filter: filter)
+                        .frame(width: 300, height: 500, alignment: .center)
+                    VStack{
+                        Button {
+                            showTotalActivity.toggle()
+                        } label: {
+                            Rectangle()
+                                .foregroundColor(.white.opacity(0.1))
+                                .frame(width: 99, height: 30)
+                            
+                        }
+                        .sheet(isPresented: $showTotalActivity) {
+                            Text("앱 사용 통계")
+                                .presentationDetents([.height(724)])
+                                .presentationDragIndicator(.visible)
+                        }
+                        
+                        Spacer()
+                            .frame(height: 390)
+                        
+                        
+                    }
+
+                    
+                }
                 
                 Spacer()
                 
@@ -85,7 +109,7 @@ struct MainView: View {
                                 .font(.custom("DOSSaemmul", size: 16))
                         }
                     }
-
+                    
                     Spacer()
                     
                     // 시간설정 버튼
@@ -101,7 +125,7 @@ struct MainView: View {
                                 .font(.custom("DOSSaemmul", size: 16))
                         }
                     }
-
+                    
                     
                     Spacer()
                     


### PR DESCRIPTION
## 개요 및 관련 이슈
메인 화면에서 사용 시간, 레벨, 스트레스 지수를 눌렀을 때 모달을 띄우기 위해 뷰를 수정했습니다.


## 작업 사항
- MainView에서 보이지 않는 버튼을 만들어 사용 시간, 레벨, 스트레스 지수 별로 모달을 띄움
- 시간 설정 버튼과 성장 일지 버튼 위치 바꿈
- 레벨 설명 작성
- 디자인 반영하여 MainActivityView의 padding 이나 frame 조정
- 인포메이션 버튼 없앰

