### PR TITLE
[Feat/#105] SettingView 키보드 키고 끄기 및 한국어 자판으로 세팅

### DIFF
--- a/PeepPeep/PeepPeep/View/Setting/SettingView.swift
+++ b/PeepPeep/PeepPeep/View/Setting/SettingView.swift
@@ -12,61 +12,70 @@ struct SettingView: View {
     
     let grayColor: Color = Color("GrayColor")
     @State var chickName: String = ""
+    @FocusState private var focusedField: Field?
     @State var showModal = false
-    //@StateObject private var keyboardResponder = KeyboardResponder()
+    
+    enum Field: Hashable {
+            case chickName
+        }
     
     var body: some View {
-        VStack(alignment: .leading) {
-            Text("설정")
-                .font(.custom("DOSSaemmul", size: 20))
-                .padding(.bottom, 21)
-            
-            HStack{
-                Text("이름")
-                    .frame(width: 30)
-                    .font(.custom("DOSSaemmul", size: 15))
-                    .foregroundColor(grayColor)
-                    .padding(EdgeInsets(top: 0, leading: 36, bottom: 0, trailing: 50))
+        ScrollView {
+            VStack(alignment: .leading) {
+                Text("설정")
+                    .font(.custom("DOSSaemmul", size: 20))
+                    .padding(.bottom, 21)
                 
-                TextField(chickName, text: $chickName)
-                    .font(.custom("DOSSaemmul", size: 15))
-                    .onSubmit {
-                        UserDefaults.shared.set(chickName, forKey: "chickName")
-                    }
-                    //.offset(y: keyboardResponder.isKeyboardVisible ? 0 : 30)
-                    //.animation(.easeInOut(duration: 0.2), value: keyboardResponder.isKeyboardVisible)
+                HStack{
+                    Text("이름")
+                        .frame(width: 30)
+                        .font(.custom("DOSSaemmul", size: 15))
+                        .foregroundColor(grayColor)
+                        .padding(EdgeInsets(top: 0, leading: 36, bottom: 0, trailing: 50))
+                    
+                    TextField(chickName, text: $chickName)
+                        .font(.custom("DOSSaemmul", size: 15))
+                        .onSubmit {
+                            UserDefaults.shared.set(chickName, forKey: "chickName")
+                        }
+                        .focused($focusedField, equals: .chickName)
+                        .textContentType(.name) // 한국어 키보드 먼저 띄우기
+                    
+                }
+                .frame(width: 320, height: 61)
+                .overlay(){
+                    RoundedRectangle(cornerRadius: 20)
+                        .stroke(.black)
+                }
+                .padding(.bottom, 35)
                 
-            }
-            .frame(width: 320, height: 61)
-            .overlay(){
-                RoundedRectangle(cornerRadius: 20)
-                    .stroke(.black)
-            }
-            .padding(.bottom, 35)
-            
-            Button {
-                self.showModal.toggle()
-            } label: {
-                Text("핸드폰 사용 시간 설정")
-                    .font(.custom("DOSSaemmul", size: 15))
-                    .foregroundColor(.black)
-            }
-            .frame(width: 320, height: 61)
-            .overlay(){
-                RoundedRectangle(cornerRadius: 20)
-                    .stroke(.black)
-            }
-            .sheet(isPresented: $showModal) {
-                TimeSettingView()
-                    .presentationDetents([.height(724)])
-                    .presentationDragIndicator(.visible)
-            }
-            
-            Spacer()
-            
-        } // VStack
+                Button {
+                    self.showModal.toggle()
+                } label: {
+                    Text("핸드폰 사용 시간 설정")
+                        .font(.custom("DOSSaemmul", size: 15))
+                        .foregroundColor(.black)
+                }
+                .frame(width: 320, height: 61)
+                .overlay(){
+                    RoundedRectangle(cornerRadius: 20)
+                        .stroke(.black)
+                }
+                .sheet(isPresented: $showModal) {
+                    TimeSettingView()
+                        .presentationDetents([.height(724)])
+                        .presentationDragIndicator(.visible)
+                }
+                
+                Spacer()
+                
+            } // VStack
+        } // ScrollView
         .onAppear{
             chickName = UserDefaults.shared.string(forKey: "chickName") ?? "병아리"
+        }
+        .onTapGesture {
+            focusedField = nil
         }
     }
 }


### PR DESCRIPTION
## 개요 및 관련 이슈

- 작업 이슈 : #105 

- Setting에서 병아리 이름 변경을 위해 TextField 클릭 시 키보드가 아래에서 뜨고, 키보드가 떴을 경우 키보드 외 영역 터치 시 키보드가 사라지게 하는 기능을 구현했습니다. 키보드는 한국어 자판으로 세팅되어 있습니다.

- 특이사항 : 수리에게 작업을 넘겨받아 진행, 완성한 코드입니다.

## 작업 사항

- TextField 클릭 시 키보드 나오기
- 키보드가 나왔을 때 다른 곳을 터치하면 키보드가 내려가기
- 키보드를 한국어 자판으로 세팅(기존 영어)

## 사진 또는 영상(Optional)
![Aug-01-2023 02-47-56](https://github.com/DeveloperAcademy-POSTECH/MC3-Team12-PeepPeep/assets/129183269/b15dbbab-02ab-4789-a14c-3a2a93de2b03)